### PR TITLE
Fix/x kubernetes preserve unknown fields

### DIFF
--- a/.ko.yaml
+++ b/.ko.yaml
@@ -1,6 +1,4 @@
-# gently copied from https://github.com/aws/karpenter-provider-aws/blob/main/.ko.yaml
-
-defaultBaseImage: public.ecr.aws/eks-distro-build-tooling/eks-distro-minimal-base
+defaultBaseImage: gcr.io/distroless/static
 defaultPlatforms:
   - linux/arm64
   - linux/amd64

--- a/README.md
+++ b/README.md
@@ -76,11 +76,13 @@ Please join our community meeting.
 * Every other Wednesday at 9AM PT (Pacific Time). [Convert to local timezone][tz-help] 
 * Agenda: [Public doc][agenda]
 * Join us: [Zoom meeting][zoom]
+* Community meeting recordings:  [YouTube channel][youtube]
 
 
 [tz-help]: http://www.thetimezoneconverter.com/?t=9%3A00&tz=PT%20%28Pacific%20Time%29
 [agenda]: https://docs.google.com/document/d/1GqeHcBlOw6ozo-qS4TLdXSi5qUn88QU6dwdq0GvxRz4/edit?tab=t.0
 [zoom]: https://us06web.zoom.us/j/85388697226?pwd=9Xxz1F0FcNUq8zFGrsRqkHMhFZTpuj.1
+[youtube]: https://www.youtube.com/channel/UCUlcI3NYq9ehl5wsdfbJzSA
 
 ## Security
 

--- a/examples/aws/webstack/Readme.md
+++ b/examples/aws/webstack/Readme.md
@@ -63,6 +63,23 @@ a new file called instance.yaml.
 ```shell
 envsubst < "webstack/instance-tmpl.yaml" > "webstack/instance.yaml"
 ```
+`clusterName` is a required field to achieve pod identity association. If your cluster name is not 'kro' then replace the value assigned to this field in the `webstack/instance.yaml` file with the name of your cluter. 
+
+<pre>
+apiVersion: kro.run/v1alpha1
+kind: WebStack
+metadata:
+  name: test-app
+spec:
+  name: my-test-app-name
+  <mark>clusterName:</mark> kro # change this value if your cluster name is not kro
+  image: candonov/s3-demo-app
+  s3bucket:
+    enabled: true
+    access: write
+  ingress:
+    enabled: true # this will expose unathenticated alb
+  service: {}`</pre>
 
 Apply the `webstack/instance.yaml`
 

--- a/examples/aws/webstack/instance-tmpl.yaml
+++ b/examples/aws/webstack/instance-tmpl.yaml
@@ -4,6 +4,7 @@ metadata:
   name: test-app
 spec:
   name: $RESOURCES_NAME
+  clusterName: kro # change this value if your cluster name is not kro
   image: candonov/s3-demo-app
   s3bucket:
     enabled: true

--- a/pkg/graph/emulator/emulator.go
+++ b/pkg/graph/emulator/emulator.go
@@ -81,6 +81,11 @@ func (e *Emulator) generateValue(schema *spec.Schema) (interface{}, error) {
 		return nil, fmt.Errorf("schema is nil")
 	}
 
+	if enabled, ok := schema.VendorExtensible.Extensions["x-kubernetes-preserve-unknown-fields"]; ok && enabled.(bool) {
+		// Handle x-kubernetes-preserve-unknown-fields
+		return e.generateObject(schema)
+	}
+
 	if enabled, ok := schema.VendorExtensible.Extensions["x-kubernetes-int-or-string"]; ok && enabled.(bool) {
 		// Default to integer for dummy CRs
 		return e.generateInteger(schema), nil
@@ -101,7 +106,8 @@ func (e *Emulator) generateValue(schema *spec.Schema) (interface{}, error) {
 			return e.generateValue(&schema.AnyOf[e.rand.Intn(len(schema.AnyOf))])
 		}
 
-		return nil, fmt.Errorf("schema type is empty and has no properties")
+    // return nil, fmt.Errorf("schema type is empty and has no properties: %+v", schema)
+    return nil, fmt.Errorf("schema type is empty and has no properties")
 	}
 
 	if len(schema.Type) != 1 {

--- a/pkg/graph/emulator/emulator.go
+++ b/pkg/graph/emulator/emulator.go
@@ -106,8 +106,8 @@ func (e *Emulator) generateValue(schema *spec.Schema) (interface{}, error) {
 			return e.generateValue(&schema.AnyOf[e.rand.Intn(len(schema.AnyOf))])
 		}
 
-    // return nil, fmt.Errorf("schema type is empty and has no properties: %+v", schema)
-    return nil, fmt.Errorf("schema type is empty and has no properties")
+		// return nil, fmt.Errorf("schema type is empty and has no properties: %+v", schema)
+		return nil, fmt.Errorf("schema type is empty and has no properties")
 	}
 
 	if len(schema.Type) != 1 {

--- a/pkg/graph/emulator/emulator_test.go
+++ b/pkg/graph/emulator/emulator_test.go
@@ -14,7 +14,6 @@
 package emulator
 
 import (
-  "fmt" // HACK: remove me, used for debugging, i need to learn to debug better...
 	"strings"
 	"testing"
 

--- a/pkg/graph/emulator/emulator_test.go
+++ b/pkg/graph/emulator/emulator_test.go
@@ -14,6 +14,7 @@
 package emulator
 
 import (
+  "fmt" // HACK: remove me, used for debugging, i need to learn to debug better...
 	"strings"
 	"testing"
 
@@ -501,6 +502,24 @@ func TestGenerateValueWithIntOrString(t *testing.T) {
 
 }
 
+func TestGenerateValueWithPreserveUnknownFields(t *testing.T) {
+	e := NewEmulator()
+
+	t.Run("x-kubernetes-preserve-unknown-fields present, does not produce error", func(t *testing.T) {
+		schema := &spec.Schema{
+			VendorExtensible: spec.VendorExtensible{
+				Extensions: map[string]interface{}{
+					"x-kubernetes-preserve-unknown-fields": true,
+				},
+			},
+		}
+
+		value, err := e.generateValue(schema)
+		require.NoError(t, err)
+	})
+
+}
+
 func ptr[T comparable](v T) *T {
 	return &v
 }
@@ -511,6 +530,6 @@ func isInt64OrString(v interface{}) bool {
 	case int64, string:
 		return true
 	default:
-		return false
+	return false
 	}
 }

--- a/pkg/graph/emulator/emulator_test.go
+++ b/pkg/graph/emulator/emulator_test.go
@@ -514,7 +514,7 @@ func TestGenerateValueWithPreserveUnknownFields(t *testing.T) {
 			},
 		}
 
-		value, err := e.generateValue(schema)
+		_, err := e.generateValue(schema)
 		require.NoError(t, err)
 	})
 

--- a/pkg/graph/emulator/emulator_test.go
+++ b/pkg/graph/emulator/emulator_test.go
@@ -529,6 +529,6 @@ func isInt64OrString(v interface{}) bool {
 	case int64, string:
 		return true
 	default:
-	return false
+		return false
 	}
 }


### PR DESCRIPTION
creating copy of pr https://github.com/kro-run/kro/pull/325 for the purposes of running the ci, test actions on my repo.


handle missing type in schema when x-kubernetes-preserve-unknown-fields is present


error message (formatted for legibility):
```
failed to build resource \"helmRelease\": 
  failed to generate dummy CR for resource helmRelease:
    error generating field spec: error generating field values:
      schema type is empty and has no properties
```